### PR TITLE
Added permission dashboard, unified user avatars

### DIFF
--- a/Database/Enums/Permissions.cs
+++ b/Database/Enums/Permissions.cs
@@ -13,7 +13,7 @@ namespace VoteMyst.Database
         EditEntries = 1uL << 4,
         ViewUsers = 1uL << 5,
 
-        AllowWinning = 1uL << 63,
+        AllowWinning = 1uL << 31,
 
         // Moderation
         DeleteEntries = 1uL << 32,
@@ -29,7 +29,7 @@ namespace VoteMyst.Database
         Banned = 0,
         Guest = ViewEntries | ViewEvents,
         Default = Guest | SubmitEntries | SubmitVotes | EditEntries | ViewUsers | AllowWinning,
-        Moderator = Default | DeleteEntries | DeleteVotes ^ AllowWinning,
+        Moderator = (Default | DeleteEntries | DeleteVotes) ^ AllowWinning,
         Admin = ulong.MaxValue ^ AllowWinning
     }
 }

--- a/Helpers/PermissionHelper.cs
+++ b/Helpers/PermissionHelper.cs
@@ -1,0 +1,30 @@
+using VoteMyst.Database;
+using VoteMyst.Database.Models;
+
+namespace VoteMyst 
+{
+    public static class PermissionHelper 
+    {
+        private const ulong _bannedMarker = 0;
+        private const ulong _moderatorMarker = 1uL << 32;
+        private const ulong _adminMarker = 1uL << 47;
+
+        public static bool IsAdmin(this UserData user)
+        {
+            return ((ulong)user.PermissionLevel) >= _adminMarker;
+        }
+
+        public static string DeterminePermissionGroup(this UserData user)
+        {
+            ulong permissions = (ulong)user.PermissionLevel;
+            if (permissions >= _adminMarker)
+                return "Admin";
+            if (permissions >= _moderatorMarker)
+                return "Moderator";
+            if (permissions == _bannedMarker)
+                return "Banned";
+
+            return null;
+        }
+    }
+}

--- a/Pages/Shared/Components/Avatar/Default.cshtml
+++ b/Pages/Shared/Components/Avatar/Default.cshtml
@@ -1,0 +1,10 @@
+@if(ViewBag.AvatarUrl != null) 
+{
+    <img class="avatar" src="@ViewBag.AvatarUrl" />
+}
+else
+{
+    <div class="avatar avatar-default">
+        <p>@ViewBag.AvatarInitials</p>
+    </div>
+}

--- a/Pages/Shared/Components/Entry/Default.cshtml
+++ b/Pages/Shared/Components/Entry/Default.cshtml
@@ -3,8 +3,8 @@
         @if(ViewBag.DisplayUser)
         {
             <div class="post-user">
-                <img src="@ViewBag.Avatar"/>
-                <p class="username">@ViewBag.Username</p>
+                @await Component.InvokeAsync("Avatar", @ViewBag.User)
+                <p class="username">@ViewBag.User.Username</p>
                 <p class="post-date">@ViewBag.Entry.SubmitDate.ToString("dd/MM/yyyy")</p>
             </div>
         }

--- a/Pages/Shared/Components/UserWidget/Default.cshtml
+++ b/Pages/Shared/Components/UserWidget/Default.cshtml
@@ -1,8 +1,8 @@
 @if (@ViewBag.IsLoggedIn)
 {
     <a href="/users/me" class="widget user-widget">
-        <img class="avatar" src="/assets/avatars/@(ViewBag.DisplayId).png" />
-        <p class="username">@ViewBag.Username</p>
+        @await Component.InvokeAsync("Avatar", @ViewBag.User)
+        <p class="username">@ViewBag.User.Username</p>
     </a>
 }
 else 

--- a/ViewComponents/AvatarViewComponent.cs
+++ b/ViewComponents/AvatarViewComponent.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authentication;
+
+using VoteMyst.Database;
+using VoteMyst.Database.Models;
+
+namespace VoteMyst.ViewComponents
+{
+    public class AvatarViewComponent : ViewComponent
+    {
+        private readonly UserProfileBuilder _profileBuilder;
+
+        public AvatarViewComponent(UserProfileBuilder profileBuilder)
+        {
+            _profileBuilder = profileBuilder;
+        }
+
+        public Task<IViewComponentResult> InvokeAsync(UserData user) 
+        {
+            ViewBag.AvatarUrl = _profileBuilder.GetAvatarUrl(user, out string initials);
+            ViewBag.AvatarInitials = initials;
+
+            return Task.FromResult<IViewComponentResult>(View());
+        }
+    }
+}

--- a/ViewComponents/EntryViewComponent.cs
+++ b/ViewComponents/EntryViewComponent.cs
@@ -25,8 +25,7 @@ namespace VoteMyst.ViewComponents
 
             // TODO: Display the user that posted the entry
             ViewBag.DisplayUser = displayUser;
-            ViewBag.Username = author.Username;
-            ViewBag.Avatar = $"/assets/avatars/{author.DisplayId}.png";
+            ViewBag.User = author;
             ViewBag.Entry = entry;
             
             return Task.FromResult<IViewComponentResult>(View());

--- a/ViewComponents/UserWidgetViewComponent.cs
+++ b/ViewComponents/UserWidgetViewComponent.cs
@@ -1,23 +1,29 @@
 using System;
+using System.IO;
 using System.Linq;
-using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
 
 using VoteMyst.Discord;
 using VoteMyst.Database;
 using VoteMyst.Database.Models;
+
 
 namespace VoteMyst.ViewComponents
 {
     public class UserWidgetViewComponent : ViewComponent
     {
         private readonly UserProfileBuilder _profileBuilder;
+        private readonly IWebHostEnvironment _environment;
 
-        public UserWidgetViewComponent(UserProfileBuilder profileBuilder)
+        public UserWidgetViewComponent(UserProfileBuilder profileBuilder, IWebHostEnvironment environment)
         {
             _profileBuilder = profileBuilder;
+            _environment = environment;
         }
 
         public Task<IViewComponentResult> InvokeAsync() 
@@ -27,10 +33,7 @@ namespace VoteMyst.ViewComponents
 
             if (loggedIn)
             {
-                UserData user = _profileBuilder.FromContext(HttpContext);
-
-                ViewBag.Username = user.Username;
-                ViewBag.DisplayId = user.DisplayId;
+                ViewBag.User = _profileBuilder.FromContext(HttpContext);
             }
 
             return Task.FromResult<IViewComponentResult>(View());

--- a/Views/User/Display.cshtml
+++ b/Views/User/Display.cshtml
@@ -1,38 +1,119 @@
+@using VoteMyst.Database.Models
 @{
     ViewData["Title"] = "User";
     Layout = "_Layout";
+
+    UserData inspectedUser = ViewBag.InspectedUser;
+    UserData selfUser = ViewBag.SelfUser;
 }
 
-<div class="user-info">
+<div class="panel user-info">
     <div class="user-info-column">
-        <img class="user-avatar" src="/assets/avatars/@(ViewBag.DisplayId).png" />
-        <p class="username">@ViewBag.Username</p>
-        @if(ViewBag.PermissionGroup != null && ViewBag.PermissionGroup != "Default") 
+        @await Component.InvokeAsync("Avatar", @ViewBag.InspectedUser)
+        <p class="username">@inspectedUser.Username</p>
+        @if(ViewBag.InspectedUserGroup != null) 
         {
-            <p class="user-badge @ViewBag.PermissionGroup.ToLower()">
-                @ViewBag.PermissionGroup
+            <p class="user-badge @ViewBag.InspectedUserGroup.ToLower()">
+                @ViewBag.InspectedUserGroup
             </p>
         }
     </div>
     <table class="user-info-table">
         <tr>
             <th>Join Date:</th>
-            <td>@ViewBag.JoinDate.ToString("dd/MM/yyyy")</td>
+            <td>@inspectedUser.JoinDate.ToString("dd/MM/yyyy")</td>
         </tr>
         <tr>
             <th>Total votes:</th>
-            <td>@ViewBag.TotalVotes</td>
+            <td>@ViewBag.InspectedTotalVotes</td>
         </tr>
         <tr>
             <th>Total submissions:</th>
-            <td>@ViewBag.TotalEntries</td>
+            <td>@ViewBag.InspectedTotalEntries</td>
         </tr>
     </table>
 
-    <a href="/logout" class="logout-button">
-        Log Out
-    </a>
+    @if(ViewBag.IsSelf)
+    {
+        <a href="/logout" class="logout-button">
+            Log Out
+        </a>
+    }
 </div>
+
+@if(ViewBag.AllowAdminDashboard)
+{
+    <form class="panel user-admin-panel" method="post">
+        <table class="user-permission-table">
+            @foreach(var entry in ViewBag.PermissionEntries)
+            {
+                <tr>
+                    <td>
+                        <p class="permission-label">@entry.Item1</p>
+                    </td>
+                    <td>
+                        <div class="permission-checkbox" 
+                            --permissionflag="@entry.Item2"
+                            @(entry.Item3 ? "checked" : "")>
+                            <div class="knob"></div>
+                        </div>
+                    </td>
+                </tr>
+            }
+        </table>
+        <table class="user-groups-table">
+            @foreach(var entry in ViewBag.PermissionGroups)
+            {
+                <tr>
+                    <td>
+                        <div class="button permission-button"
+                            --permissionflag="@entry.Item2">Apply @entry.Item1</div>
+                    </td>
+                </tr>
+            }
+        </table>
+        <input type="hidden" name="userId" value="@ViewBag.InspectedUser.DisplayId" />
+        <input type="hidden" name="permissions" value="0" />
+        <button type="submit">Update Permissions</button>
+    </form>
+
+    <script>
+        function recalculatePermissions() {
+            let permissions = 0n;
+            document.querySelectorAll(".permission-checkbox")
+                .forEach(c => {
+                    if (c.hasAttribute("checked")) {
+                        permissions += BigInt(c.getAttribute("--permissionflag"));
+                    }
+                });
+            document.forms[0]["permissions"].value = permissions;
+        }
+        function applyPermissions(permissions) {
+            document.querySelectorAll(".permission-checkbox")
+                .forEach(c => {
+                    let mask = BigInt(c.getAttribute("--permissionflag"));
+                    if ((permissions & mask) != 0) {
+                        c.setAttribute("checked", "");
+                    }
+                    else {
+                        c.removeAttribute("checked");
+                    }
+                });
+            document.forms[0]["permissions"].value = permissions;
+        }
+        recalculatePermissions();
+
+        document.querySelectorAll(".permission-checkbox")
+            .forEach(c => c.addEventListener("click", e => {
+                c.toggleAttribute("checked");
+                recalculatePermissions();
+            }));
+        document.querySelectorAll(".permission-button")
+            .forEach(c => c.addEventListener("click", e => {
+                applyPermissions(BigInt(c.getAttribute("--permissionflag")));
+            }));
+    </script>
+}
 
 <input style="display:none" type="checkbox" checked="true" onchange="theme()" />
 

--- a/wwwroot/css/forms.css
+++ b/wwwroot/css/forms.css
@@ -25,8 +25,9 @@ input:focus, select:focus, textarea:focus {
     outline: none;
 }
 
-button {
+button, .button {
     display: inline-block;
+    margin: 1rem 0;
     height: 38px;
     line-height: 38px;
     padding: 0 30px;
@@ -38,15 +39,16 @@ button {
     font-weight: bold;
     letter-spacing: 0.1rem;
     text-transform: uppercase;
+    text-align: center;
     cursor: pointer;
+    white-space: nowrap;
 }
-button:hover {
+button:hover, .button:hover {
     background-color: var(--color-nanolight);
     color: var(--color-white);
 }
 
 .form-submit {
-    margin: 1.5rem 0;
 }
 .form-submit span {
     margin: auto 30px;

--- a/wwwroot/css/layout.css
+++ b/wwwroot/css/layout.css
@@ -25,6 +25,13 @@ h1 {
     margin: auto;
 }
 
+.panel {
+    background-color: var(--color-nanolight);
+    border-radius: 10px;
+    padding: 10px;
+    margin: 3rem 0;
+}
+
 .heading {
     font-size: 3.5rem;
     justify-self: flex-start;
@@ -49,6 +56,7 @@ nav {
     margin: auto;
     width: fit-content;
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
     background-color: var(--color-nanolight);
     border-radius: 10px;

--- a/wwwroot/css/posts.css
+++ b/wwwroot/css/posts.css
@@ -65,11 +65,10 @@
     align-items: center;
     height: 48px;
 }
-.post .post-user img {
-    height: 70%;
-    margin: 10% 5px;
-    border-radius: 50%;
-    display: inline-block;
+.post .post-user .avatar {
+    height: calc(0.7 * 48px);
+    width: calc(0.7 * 48px);
+    margin: auto 5px;
 }
 .post .post-user .username {
     font-size: 0.9rem;

--- a/wwwroot/css/submit.css
+++ b/wwwroot/css/submit.css
@@ -2,8 +2,6 @@ form.entry-form {
     margin: 18px auto;
 }
 
-
-
 .disclaimer {
     margin: 2rem 0;
     padding-left: 1rem;

--- a/wwwroot/css/user.css
+++ b/wwwroot/css/user.css
@@ -1,14 +1,13 @@
 .widget {
     display: block;
     margin: auto 0 auto auto;
-    height: 48px;
+    height: var(--user-widget-height);
     border-radius: 25px;
     cursor: pointer;
 }
 
 @media (max-width: 640px) {
     .widget {
-        height: 42px;
         margin: 10px auto 10px 10px;
     }
 }
@@ -18,9 +17,9 @@
     background-color: var(--color-nanolight);
 }
 .user-widget .avatar {
-    height: 100%;
-    border-radius: 50%;
+    height: var(--user-widget-height);
 }
+
 .user-widget .username {
     margin: auto 20px auto 10px;
 }
@@ -46,25 +45,46 @@
     color: white;
 }
 
+.avatar {
+    border-radius: 50%;
+}
+.avatar.avatar-default {
+    width: var(--user-widget-height);
+    height: var(--user-widget-height);
+    background-color: var(--color-mystge);
+    display: flex;
+}
+.avatar.avatar-default p {
+    text-align: center;
+    font-size: 1.3rem;
+    font-weight: bolder;
+    line-height: 100%;
+    margin: auto;
+    color: black;
+}
+
 .user-info {
     display: flex;
     flex-direction: row;
-    background-color: var(--color-nanolight);
-    border-radius: 10px;
-    padding: 10px;
-    margin: 3rem 0;
 }
 
 .user-info .user-info-column {
     margin: 10px;
 }
 
-.user-info .user-avatar {
+.user-info .avatar {
     display: block;
     margin: auto;
-    width: 100%;
-    max-width: 128px;
+    width: 128px;
     border-radius: 50%;
+}
+.user-info .avatar-default {
+    height: 128px;
+    display: flex;
+}
+.user-info .avatar-default p {
+    margin: auto;
+    font-size: 2rem;
 }
 
 .user-info .username {
@@ -102,6 +122,7 @@
 
 .user-info .user-info-table {
     margin: 30px 10px;
+    white-space: nowrap;
 }
 .user-info .user-info-table tr {
     line-height: 1.5rem;
@@ -126,6 +147,62 @@
 .user-info .logout-button:hover {
     background-color: #a81313;
     color: white;
+}
+
+.user-admin-panel {
+    display: flex;
+    flex-direction: row;
+    box-sizing: border-box;
+}
+.user-admin-panel > * {
+    margin: 5px 25px;
+}
+.user-admin-panel button[type=submit] {
+    margin: auto 0 0 auto;
+}
+.user-permission-table {
+
+}
+.user-admin-panel .permission-label {
+    padding-right: 1rem;
+    margin: 0;
+}
+
+.user-admin-panel .permission-checkbox {
+    position: relative;
+    width: 2rem;
+    height: 1rem;
+    border-radius: 0.5rem;
+    background-color: #801919;
+    transition: background-color 0.2s;
+    cursor: pointer;
+}
+.user-admin-panel .permission-checkbox[checked] {
+    background-color: #3b8a3b;
+}
+.user-admin-panel .permission-checkbox .knob {
+    content: "";
+    left: 0;
+    transition: left 0.2s;
+    position: absolute;
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    background-color: white;
+}
+.user-admin-panel .permission-checkbox[checked] .knob {
+    left: 50%;
+}
+
+.user-admin-panel .permission-button {
+    margin: auto;
+    width: 100%;
+    height: 28px;
+    line-height: 28px;
+    letter-spacing: 0.06rem;
+    padding: 0 15px;
+    box-sizing: border-box;
 }
 
 @media (max-width: 640px) {

--- a/wwwroot/css/variables-dark.css
+++ b/wwwroot/css/variables-dark.css
@@ -13,4 +13,14 @@
     
     --color-badge-admin: #9a90ff;
     --color-badge-banned: #bd1c1c;
+
+    --user-widget-height: 48px;
+}
+
+@media (max-width: 640px)
+{
+    :root 
+    {
+        --user-widget-height: 40px;
+    }
 }


### PR DESCRIPTION
Implemented at the `user/{id}` endpoint. Only is shown if:
- the user displayed is not the self user
- the self user is an admin
- the user displayed is not an admin

In the future, a feature to remove admin roles (without manual database access) will have to be added.