### PR TITLE
Added semantic versioning, closes #76

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,6 @@
-﻿<!DOCTYPE html>
+﻿@inject SemVer Version
+
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <title>@ViewData["Title"] - VoteMyst</title>
@@ -34,6 +36,7 @@
                 <h1>
                     <img src="/img/trophy.png"/>
                     <span>VoteMyst</span>
+                    <sub class="version">v<span>@Version.VersionString</span></sub>
                 </h1>
             </a>
             <partial name="_UserWidget" />

--- a/SemVer.cs
+++ b/SemVer.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Diagnostics;
+
+namespace VoteMyst
+{
+    /// <summary>
+    /// Provides access to the semantic version of the project.
+    /// </summary>
+    public class SemVer
+    {
+        /// <summary>
+        /// Returns the semantic version as a <see cref="System.Version"/> object.
+        /// </summary>
+        public Version SystemVersion => new Version(Major, Minor, Patch);
+        /// <summary>
+        /// Returns the semantic version as a version string in the format 'Major.Minor.Patch'.
+        /// </summary>
+        public string VersionString => $"{Major}.{Minor}.{Patch}";
+
+        /// <summary>
+        /// The major component of the version.
+        /// </summary>
+        public int Major { get; } = 0;
+        /// <summary>
+        /// The minor component of the version.
+        /// </summary>
+        public int Minor { get; } = 0;
+        /// <summary>
+        /// The patch component of the version.
+        /// </summary>
+        public int Patch { get; } = 0;
+
+        /// <summary>
+        /// Creates a new instance of the semantic version for the project, by analyzing the git history.
+        /// </summary>
+        public SemVer()
+        {
+            // Try to locate the latest tag from the git history.
+            string baseVersion = CaptureOutputFromProcess("git", "describe --tags --abbrev=0").Trim('\n', ' ');
+
+            // If an empty string was returned then a tag has not been set yet. Use a zero-based version instead.
+            bool hasTagVersion = !string.IsNullOrEmpty(baseVersion);
+            if (!hasTagVersion)
+                baseVersion = "v0.0.0";
+
+            // Split the version string to extract the version components. Skip the first character 'v'.
+            string[] versionSegments = baseVersion.Substring(1).Split('.');
+            if (hasTagVersion && versionSegments != null && versionSegments.Length > 0) 
+            {
+                if (versionSegments.Length >= 1 && int.TryParse(versionSegments[0], out int major))
+                    Major = major;
+                if (versionSegments.Length >= 2 && int.TryParse(versionSegments[1], out int minor))
+                    Minor = minor;
+                if (versionSegments.Length >= 3 && int.TryParse(versionSegments[2], out int patch))
+                    Patch = patch;
+            }
+
+            // Iterate over the reversed commits, scanning for semver messages (::major, ::minor, ::patch).
+            string[] commits = CaptureOutputFromProcess("git", $"log {(hasTagVersion ? baseVersion + "..HEAD " : "")}-i --oneline --reverse").Split('\n');
+            foreach (string commit in commits)
+            {
+                if (commit.Contains("::patch"))
+                {
+                    Patch++;
+                }
+                else if (commit.Contains("::minor")) 
+                {
+                    Minor++;
+                    Patch = 0;
+                }
+                else if (commit.Contains("::major"))
+                {
+                    Major++;
+                    Minor = 0;
+                    Patch = 0;
+                }
+            }
+        }
+
+        private string CaptureOutputFromProcess(string filename, params string[] args)
+        {
+            using Process p = new Process();
+
+            p.StartInfo.FileName = filename;
+            p.StartInfo.Arguments = string.Join(' ', args);
+            p.StartInfo.UseShellExecute = false;
+            p.StartInfo.RedirectStandardOutput = true;
+
+            p.Start();
+
+            string output = p.StandardOutput.ReadToEnd();
+            p.WaitForExit();
+
+            return output;
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -38,6 +38,8 @@ namespace VoteMyst
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton<SemVer>();
+
             services.AddRazorPages();
           
             services.AddSingleton(Configuration);

--- a/wwwroot/css/layout.css
+++ b/wwwroot/css/layout.css
@@ -32,7 +32,13 @@ h1 {
     margin: auto;
 }
 
+header {
+    display: flex;
+    flex-direction: row;
+    margin: 10px 0 20px;
+}
 header h1 {
+    position: relative;
     margin: 10px 0;
     justify-self: flex-start;
     font-size: 3.5rem;
@@ -42,11 +48,12 @@ header h1 img {
     height: 50px;
     top: 5px;
 }
-
-header {
-    display: flex;
-    flex-direction: row;
-    margin: 10px 0 20px;
+header h1 .version {
+    position: absolute;
+    top: 44px;
+    right: 0;
+    color: var(--color-gray);
+    font-size: 0.9rem;
 }
 
 hr {


### PR DESCRIPTION
Added a semantic versioning system to the project.

The version will be read once on startup and will then be kept as a singleton that can be injected into views.

Versions can be bumped by including `::major`, `::minor` and/or `::bump` inside a commit message. This behaviour can be overridden by creating a new tag.